### PR TITLE
Perform address resolution only once

### DIFF
--- a/app/src/main/java/sk/madzik/android/logcatudp/LogcatThread.java
+++ b/app/src/main/java/sk/madzik/android/logcatudp/LogcatThread.java
@@ -37,6 +37,7 @@ public class LogcatThread extends Thread {
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String logLine;
             boolean socketFailed = false;
+            InetAddress destAddress = InetAddress.getByName(mConfig.mDestServer);
             while (true) {
                 String sendingLine = "";
                 // assume that log writes whole lines
@@ -47,7 +48,7 @@ public class LogcatThread extends Thread {
                     }
                     sendingLine += logLine + System.getProperty("line.separator");
                     DatagramPacket packet = new DatagramPacket(sendingLine.getBytes(), sendingLine.length(),
-                            InetAddress.getByName(mConfig.mDestServer), mConfig.mDestPort);
+                            destAddress, mConfig.mDestPort);
                     try {
                         mSocket.send(packet);
                         if (socketFailed) {


### PR DESCRIPTION
In the original code the log thread performes address resolution for every log line.
On my android tablet this generates two additional log lines like these:
`D/libc-netbsd( 1696): [getaddrinfo]: ai_addrlen=0; ai_canonname=(null); ai_flags=4; ai_family=0`
`D/libc-netbsd( 1696): [getaddrinfo]: hostname=loghost; servname=(null); cache_mode=(null), netid=0; mark=0`

This patch moves the address resolution out of the inner loop and performs it only once at the beginning.